### PR TITLE
Switch chunky_png out for mini_magick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /spec/reports/
 /tmp/
 /*.png
+/*.jpg
+/*.gif

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ruby library for generating images from GeoJSON
 
 ## Installation
 
-Add this line to your application's Gemfile:
+You will need ImageMagick installed. Then Add this line to your application's Gemfile:
 
 ```ruby
 gem 'geojson2image'
@@ -27,7 +27,7 @@ g2i = Geojson2image::Convert.new(
   json: gjson,
   width: 500,
   height: 500,
-  output: "output.png"
+  output: "output.jpg"
 )
 g2i.to_image
 # => #<File:output.png (closed)>

--- a/geojson2image.gemspec
+++ b/geojson2image.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "oj", "~> 2.18"
-  spec.add_dependency "chunky_png", "~> 1.3.8"
+  spec.add_dependency "mini_magick", "~> 4.6.0"
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
ImageMagick is going to be more robust for drawing GeoJSON features, this switches out chunky_png drawing library for mini_magick gem to build ImageMagick commands.